### PR TITLE
Feat: поддержка формата зависимостей roles

### DIFF
--- a/plans/0002_roles_format_support.md
+++ b/plans/0002_roles_format_support.md
@@ -1,0 +1,166 @@
+# Поддержка формата ReqRoles (YAML с ключом `roles`)
+
+## Контекст
+
+Проект `reqs-up` — CLI-утилита для обновления semver-версий в Ansible `requirements.yml` файлах.
+
+Существующие форматы:
+- `ReqList` — top-level массив
+- `ReqCollections` — top-level объект с ключом `collections`
+
+Необходимо добавить поддержку формата `ReqRoles` (top-level объект с ключом `roles`):
+```yaml
+---
+roles:
+  - src: git@gitlab.example.com:infrastructure/ansible-roles/linux_tech_user.git
+    version: 1.0.2
+    scm: git
+  - src: git@gitlab.example.com:infrastructure/ansible-roles/local-entrypoint.git
+    version: master
+    scm: git
+```
+
+## Ключевые характеристики формата
+
+| Характеристика | ReqRoles |
+|----------------|----------|
+| Top-level тип | Объект `{roles: []}` |
+| URL-ключ | `src` |
+| SCM-ключ | `scm` |
+
+Формат `ReqRoles` идентичен `ReqList` по структуре элементов, но использует top-level ключ `roles` для обёртки.
+
+## Реализация
+
+### 1. Enum `YAMLFormat` (`src/reqs-up.cr:17-20`)
+
+Добавить значение `ReqRoles`:
+```crystal
+enum YAMLFormat
+  ReqList
+  ReqCollections
+  ReqRoles
+end
+```
+
+### 2. Определение формата (`src/reqs-up.cr:37-45`)
+
+Обновить метод `detect_format`:
+```crystal
+private def detect_format : YAMLFormat
+  if @yaml.as_h? && @yaml.as_h.has_key?("collections")
+    YAMLFormat::ReqCollections
+  elsif @yaml.as_h? && @yaml.as_h.has_key?("roles")
+    YAMLFormat::ReqRoles
+  elsif @yaml.as_a?
+    YAMLFormat::ReqList
+  else
+    raise "Unsupported YAML format: expected array or object with 'collections' or 'roles' key"
+  end
+end
+```
+
+### 3. Парсинг (`src/reqs-up.cr:56-81`)
+
+Добавить метод `parse_roles`:
+```crystal
+private def parse_roles
+  roles = @yaml["roles"].as_a
+  roles.each do |y|
+    Log.debug { "#{y}" }
+    next unless y["src"]? || y["source"]?
+    case y["scm"]?.try(&.as_s)
+    when "git"
+      @reqs << GitReq.new(y)
+    else
+      @reqs << DefaultReq.new(y)
+    end
+  end
+end
+```
+
+Обновить метод `parse`:
+```crystal
+private def parse
+  case @format
+  when YAMLFormat::ReqList
+    parse_req_list
+  when YAMLFormat::ReqCollections
+    parse_collections
+  when YAMLFormat::ReqRoles
+    parse_roles
+  end
+end
+```
+
+### 4. Dump с сохранением формата (`src/reqs-up.cr:83-98`)
+
+Обновить метод `dump`:
+```crystal
+def dump : String
+  case @format
+  when YAMLFormat::ReqList
+    YAML.dump(@reqs) + "...\n"
+  when YAMLFormat::ReqCollections
+    collections_yaml = @reqs.map(&.original_yaml) + @preserved_entries
+    YAML.dump({"collections" => collections_yaml})
+  when YAMLFormat::ReqRoles
+    roles_yaml = @reqs.map(&.original_yaml)
+    YAML.dump({"roles" => roles_yaml})
+  else
+    raise "Unknown format"
+  end
+end
+```
+
+## Тесты
+
+### Добавить в `spec/reqs-up_spec.cr`
+
+Блок тестов для формата `ReqRoles` (аналогично `ReqCollections`):
+- Парсинг файла `roles-requirements.yml`
+- Сохранение всех entries без потери данных
+- Корректное определение формата
+- Dump формата `ReqRoles`
+
+### Фикстуры
+
+Использовать существующую фикстуру:
+- `spec/fixtures/roles-requirements.yml`
+
+## Файлы изменений
+
+| Файл | Изменения |
+|------|-----------|
+| `src/reqs-up.cr` | YAMLFormat enum, format detection, парсинг ReqRoles, dump |
+| `spec/reqs-up_spec.cr` | Тесты для ReqRoles |
+| `shard.yml` | Обновление версии (0.0.14 → 0.1.0) |
+
+## Ветка
+
+`feature/add-roles-format-support`
+
+## Команды для проверки
+
+```bash
+# Запуск тестов
+crystal spec
+
+# Сборка бинарника
+crystal build src/main.cr -o bin/reqs-up
+
+# Проверка на новом формате
+./bin/reqs-up --dry-run --file spec/fixtures/roles-requirements.yml
+
+# Линтинг
+ameba
+```
+
+## Критерии приёмки
+
+- [ ] Код компилируется без ошибок
+- [ ] Все тесты проходят (включая новые для ReqRoles)
+- [ ] Формат `roles` корректно определяется и парсится
+- [ ] Dump сохраняет структуру с ключом `roles`
+- [ ] Версия в `shard.yml` обновлена до 0.1.0
+- [ ] ameba не выявляет проблем

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: reqs-up
-version: 0.0.14
+version: 0.1.0
 
 authors:
   - Evgenii Tereshkov <evg.krsk@gmail.com>

--- a/spec/fixtures/roles-requirements.yml
+++ b/spec/fixtures/roles-requirements.yml
@@ -1,0 +1,8 @@
+---
+roles:
+  - src: git@gitlab.example.com:infrastructure/iac/ansible-roles/linux_tech_user.git
+    version: 1.0.2
+    scm: git
+  - src: git@gitlab.example.com:infrastructure/iac/ansible-roles/local-entrypoint.git
+    version: master
+    scm: git

--- a/spec/reqs-up_spec.cr
+++ b/spec/reqs-up_spec.cr
@@ -112,6 +112,69 @@ describe ReqsUp do
       end
     end
 
+    describe "#initialize - ReqRoles формат" do
+      it "парсит файл с roles top-level ключом" do
+        file = File.new("spec/fixtures/roles-requirements.yml")
+        reqs = ReqsUp::Requirements.new(file)
+        reqs.format.should eq(ReqsUp::YAMLFormat::ReqRoles)
+      end
+
+      it "сохраняет все entries без потери данных" do
+        file = File.new("spec/fixtures/roles-requirements.yml")
+        input_yaml = YAML.parse(file.gets_to_end)
+        file.close
+        entries_with_source = input_yaml["roles"].as_a.select { |e| e["src"]? || e["source"]? }
+        input_count = entries_with_source.size
+
+        reqs = ReqsUp::Requirements.new(File.new("spec/fixtures/roles-requirements.yml"))
+        reqs.reqs.size.should eq(input_count)
+
+        dumped = reqs.dump
+        entries_with_source.each do |entry|
+          src = entry["src"]?.try(&.as_s) || entry["source"].as_s
+          dumped.should contain(src)
+          if entry["name"]?
+            name = entry["name"].as_s
+            dumped.should contain(name)
+          end
+        end
+      end
+
+      it "сохраняет ключи src и scm для git-репозиториев в roles" do
+        file = File.new("spec/fixtures/roles-requirements.yml")
+        input_yaml = YAML.parse(file.gets_to_end)
+        file.close
+
+        reqs = ReqsUp::Requirements.new(File.new("spec/fixtures/roles-requirements.yml"))
+        dumped = reqs.dump
+
+        input_yaml["roles"].as_a.each do |entry|
+          if entry["src"]?
+            dumped.should contain("src:")
+          end
+          if entry["scm"]?
+            dumped.should contain("scm:")
+          end
+        end
+      end
+
+      it "корректно определяет формат ReqRoles" do
+        file = File.new("spec/fixtures/roles-requirements.yml")
+        reqs = ReqsUp::Requirements.new(file)
+        reqs.format.should eq(ReqsUp::YAMLFormat::ReqRoles)
+        reqs.reqs.size.should eq(2)
+      end
+
+      it "dump сохраняет структуру с ключом roles" do
+        file = File.new("spec/fixtures/roles-requirements.yml")
+        reqs = ReqsUp::Requirements.new(file)
+        dumped = reqs.dump
+        dumped.should contain("roles:")
+        dumped.should contain("git@gitlab.example.com:infrastructure/iac/ansible-roles/linux_tech_user.git")
+        dumped.should contain("git@gitlab.example.com:infrastructure/iac/ansible-roles/local-entrypoint.git")
+      end
+    end
+
     describe "#initialize - ошибки" do
       it "выбрасывает при неизвестном формате YAML" do
         test_file = "spec/fixtures/invalid_test.yml"

--- a/src/reqs-up.cr
+++ b/src/reqs-up.cr
@@ -17,6 +17,7 @@ module ReqsUp
   enum YAMLFormat
     ReqList
     ReqCollections
+    ReqRoles
   end
 
   # Describes requirements.yml object
@@ -38,10 +39,12 @@ module ReqsUp
     private def detect_format : YAMLFormat
       if @yaml.as_h? && @yaml.as_h.has_key?("collections")
         YAMLFormat::ReqCollections
+      elsif @yaml.as_h? && @yaml.as_h.has_key?("roles")
+        YAMLFormat::ReqRoles
       elsif @yaml.as_a?
         YAMLFormat::ReqList
       else
-        raise "Unsupported YAML format: expected array or object with 'collections' key"
+        raise "Unsupported YAML format: expected array or object with 'collections' or 'roles' key"
       end
     end
 
@@ -51,6 +54,8 @@ module ReqsUp
         parse_req_list
       when YAMLFormat::ReqCollections
         parse_collections
+      when YAMLFormat::ReqRoles
+        parse_roles
       end
     end
 
@@ -84,6 +89,20 @@ module ReqsUp
       end
     end
 
+    private def parse_roles
+      roles = @yaml["roles"].as_a
+      roles.each do |y|
+        Log.debug { "#{y}" }
+        next unless y["src"]? || y["source"]?
+        case y["scm"]?.try(&.as_s)
+        when "git"
+          @reqs << GitReq.new(y)
+        else
+          @reqs << DefaultReq.new(y)
+        end
+      end
+    end
+
     # Return YAML dump of internal state
     def dump : String
       case @format
@@ -92,6 +111,9 @@ module ReqsUp
       when YAMLFormat::ReqCollections
         collections_yaml = @reqs.map(&.original_yaml) + @preserved_entries
         YAML.dump({"collections" => collections_yaml})
+      when YAMLFormat::ReqRoles
+        roles_yaml = @reqs.map(&.original_yaml)
+        YAML.dump({"roles" => roles_yaml})
       else
         raise "Unknown format"
       end


### PR DESCRIPTION
## Summary
- Добавлена поддержка формата `ReqRoles` (YAML с ключом `roles`)
- Обновлены `YAMLFormat` enum, `detect_format`, `parse`, `dump` методы
- Добавлены тесты для нового формата
- Версия обновлена до 0.1.0

## Testing
- Все тесты проходят (38 examples, 0 failures)
- ameba не выявляет проблем